### PR TITLE
Migrate mcp weather examples to default use streamable http

### DIFF
--- a/acp/acp_weather_service/src/acp_weather_service/agent.py
+++ b/acp/acp_weather_service/src/acp_weather_service/agent.py
@@ -85,7 +85,7 @@ def get_token() -> str:
             {"name": "LLM_API_BASE", "description": "Base URL for OpenAI-compatible API endpoint"},
             {"name": "LLM_API_KEY", "description": "API key for OpenAI-compatible API endpoint"},
             {"name": "MCP_URL", "description": "MCP Server URL for the weather tool"},
-            {"name": "ACP_MCP_TRANSPORT", "description": "MCP transport type: sse, stdio, streamable_http, websocket (defaults to 'sse')"},
+            {"name": "ACP_MCP_TRANSPORT", "description": "MCP transport type: sse, stdio, streamable_http, websocket (defaults to 'streamable_http')"},
         ],
         ui={"type": "hands-off", "user_greeting": "Ask me about the weather"},
         examples={

--- a/acp/acp_weather_service/src/acp_weather_service/graph.py
+++ b/acp/acp_weather_service/src/acp_weather_service/graph.py
@@ -15,8 +15,8 @@ class ExtendedMessagesState(MessagesState):
 def get_mcpclient():
     return MultiServerMCPClient({
         "math": {
-            "url": os.getenv("MCP_URL", "http://localhost:8000/sse"),
-            "transport": os.getenv("ACP_MCP_TRANSPORT", "sse"),
+            "url": os.getenv("MCP_URL", "http://localhost:8000/mcp"),
+            "transport": os.getenv("ACP_MCP_TRANSPORT", "streamable_http"),
         }
     })
 

--- a/mcp/weather_tool/weather_tool.py
+++ b/mcp/weather_tool/weather_tool.py
@@ -30,7 +30,7 @@ def get_weather(city: str) -> str:
 # host can be specified with HOST env variable
 # transport can be specified with MCP_TRANSPORT env variable (defaults to sse)
 def run_server():
-    transport = os.getenv("MCP_TRANSPORT", "sse")
+    transport = os.getenv("MCP_TRANSPORT", "streamable-http")
     mcp.run(transport=transport) 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So we do not have to support the deprecated `sse` transport in mcp. Opened an issue in main kagenti repo to migrate the required pieces to streamable http