### PR TITLE
fix the problem where slack_tool listens to 127.0.0.1

### DIFF
--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -30,6 +30,6 @@ def get_auth():
     else:
         return AuthSettings(
                 issuer_url=AnyHttpUrl(issuer),  # Authorization Server URL
-                resource_server_url=AnyHttpUrl("http://localhost:8000"),  # TODO This server's URL
+                resource_server_url=AnyHttpUrl("http://0.0.0.0:8000"),  # TODO This server's URL
                 required_scopes=[],
               )

--- a/mcp/slack_tool/slack_tool.py
+++ b/mcp/slack_tool/slack_tool.py
@@ -19,7 +19,7 @@ except Exception as e:
     print(f"An unexpected error occurred during Slack client initialization: {e}")
     slack_client = None
 
-mcp = FastMCP("Slack", port=8000,
+mcp = FastMCP("Slack", host="0.0.0.0", port=8000,
               token_verifier=get_token_verifier(),
               auth=get_auth(),
         )

--- a/mcp/weather_tool/weather_tool.py
+++ b/mcp/weather_tool/weather_tool.py
@@ -2,7 +2,7 @@ import os
 import requests
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("Weather", port=8000)
+mcp = FastMCP("Weather", host="0.0.0.0", port=8000)
 
 @mcp.tool()
 def get_weather(city: str) -> str:


### PR DESCRIPTION
As discussed on slack, new FASTMCP library seems to default to 127.0.0.1 when host is not specified, which is not what we want. We should explicitly specify 0.0.0.0, so other pods in the cluster can reach our mcp servers. This PR also fixes this problem for weather_tool as well.