### PR TITLE
Slack token verification

### DIFF
--- a/mcp/slack_tool/README.md
+++ b/mcp/slack_tool/README.md
@@ -10,7 +10,7 @@ You can configure the server with the following environment variables:
 | Variable name            | Required? | Default                | Description |
 | ------------------------ | --------- | ---------------------- | ----------------------------- |
 | `SLACK_BOT_TOKEN`        | Yes       | `YOUR_SLACK_BOT_TOKEN` | Access token for the Slack server |
-| `LOG_LEVEL`              | No        | `INFO`                 | Application log level |
+| `LOG_LEVEL`              | No        | `DEBUG`                | Application log level |
 | `MCP_TRANSPORT`          | No        | `streamable-http`      | Passed into mcp.run to determine mcp transport |
 | `ISSUER`                 | No        | - | If populated, will publish that it is OAuth-secured by this issuer (but no actual verification). Must be URI format |
 | `INTROSPECTION_ENDPOINT` | No        | - | If populated, will extract access tokens from requests and introspect them here |

--- a/mcp/slack_tool/README.md
+++ b/mcp/slack_tool/README.md
@@ -13,8 +13,13 @@ You can configure the server with the following environment variables:
 | `LOG_LEVEL`              | No        | `DEBUG`                | Application log level |
 | `MCP_TRANSPORT`          | No        | `streamable-http`      | Passed into mcp.run to determine mcp transport |
 | `ISSUER`                 | No        | - | If populated, will publish that it is OAuth-secured by this issuer (but no actual verification). Must be URI format |
-| `INTROSPECTION_ENDPOINT` | No        | - | If populated, will extract access tokens from requests and introspect them here |
-| `AUDIENCE `              | No.       | - | If populated with `INTROSPECTION_ENDPOINT` will perform audience validation |
+| `INTROSPECTION_ENDPOINT` | No        | - | If populated with `CLIENT_NAME` and `CLIENT_SECRET`, will introspect access tokens at this endpoint |
+| `CLIENT_NAME`            | No        | - | If populated with `INTROSPECTION_ENDPOINT` and `CLIENT_SECRET`, will introspect access tokens using this as the client id to authenticate |
+| `CLIENT_SECRET`          | No        | - | If populated with `INTROSPECTION_ENDPOINT` and `CLIENT_NAME`, will introspect access tokens using this as the client secret to authenticate |
+| `AUDIENCE `              | No        | - | If populated with `INTROSPECTION_ENDPOINT` will perform audience validation |
+
+Note: all three of `INTROSPECTION_ENDPOINT`, `CLIENT_NAME`, and `CLIENT_SECRET` are required for token validation to occur. `AUDIENCE` enables the additional audience check. 
+
 
 You can run this locally with `uv run slack_tool.py` so long as the `SLACK_BOT_TOKEN` is set. 
 

--- a/mcp/slack_tool/README.md
+++ b/mcp/slack_tool/README.md
@@ -7,11 +7,14 @@ This is a simple Slack MCP Server with two tools:
 
 You can configure the server with the following environment variables:
 
-| Variable name     | Required? | Default                | Description |
-| ----------------- | --------- | ---------------------- | ----------------------------- |
-| `SLACK_BOT_TOKEN` | Yes       | `YOUR_SLACK_BOT_TOKEN` | Access token for the Slack server |
-| `MCP_TRANSPORT`   | No        | `streamable-http`      | Passed into mcp.run to determine mcp transport |
-| `ISSUER`          | No        | - | If populated, will attempt to extract bearer token, fail otherwise. Must be URI format |
+| Variable name            | Required? | Default                | Description |
+| ------------------------ | --------- | ---------------------- | ----------------------------- |
+| `SLACK_BOT_TOKEN`        | Yes       | `YOUR_SLACK_BOT_TOKEN` | Access token for the Slack server |
+| `LOG_LEVEL`              | No        | `INFO`                 | Application log level |
+| `MCP_TRANSPORT`          | No        | `streamable-http`      | Passed into mcp.run to determine mcp transport |
+| `ISSUER`                 | No        | - | If populated, will publish that it is OAuth-secured by this issuer (but no actual verification). Must be URI format |
+| `INTROSPECTION_ENDPOINT` | No        | - | If populated, will extract access tokens from requests and introspect them here |
+| `AUDIENCE `              | No.       | - | If populated with `INTROSPECTION_ENDPOINT` will perform audience validation |
 
 You can run this locally with `uv run slack_tool.py` so long as the `SLACK_BOT_TOKEN` is set. 
 

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -7,7 +7,7 @@ from mcp.server.auth.settings import AuthSettings
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), stream=sys.stdout, format='%(levelname)s: %(message)s')
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "DEBUG"), stream=sys.stdout, format='%(levelname)s: %(message)s')
 
 
 class SimpleTokenVerifier(TokenVerifier):

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -12,9 +12,10 @@ logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format='%(levelname)
 
 class SimpleTokenVerifier(TokenVerifier):
     """Simple token verifier for demonstration."""
-    def __init__(self, introspection_endpoint = None, client_id = None):
+    def __init__(self, introspection_endpoint = None, client_id = None, client_secret = None):
         self.introspection_endpoint = introspection_endpoint
         self.client_id = client_id
+        self.client_secret = client_secret
 
     def _dummy_token(self, token: str) -> AccessToken | None:
         return AccessToken(
@@ -36,7 +37,11 @@ class SimpleTokenVerifier(TokenVerifier):
             try:
                 response = client.post(
                     self.introspection_endpoint,
-                    data={"token": token},
+                    data={
+                        "token": token,
+                        "client_id": self.client_id,
+                        "client_secret": self.client_secret,
+                    },
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 )
                 logger.debug(f"Response to token introspection: {response}")
@@ -79,10 +84,13 @@ class SimpleTokenVerifier(TokenVerifier):
 def get_token_verifier():
     introspection_endpoint = os.getenv("INTROSPECTION_ENDPOINT")
     client_id = os.getenv("CLIENT_NAME")
+    client_secret = os.getenv("CLIENT_SECRET")
     if introspection_endpoint is None:
         return None
     else:
-        return SimpleTokenVerifier(introspection_endpoint=introspection_endpoint, client_id=client_id)
+        return SimpleTokenVerifier(introspection_endpoint=introspection_endpoint, 
+                                   client_id=client_id,
+                                   client_secret=client_secret)
 
 def get_auth():
     issuer = os.getenv("ISSUER")

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -47,10 +47,11 @@ class SimpleTokenVerifier(TokenVerifier):
                 logger.debug(f"Response to token introspection: {response}")
 
                 if response.status_code != 200:
-                    logger.debug(f"Token introspection returned status {response.status_code}")
+                    logger.error(f"Token introspection returned status {response.status_code}")
                     return None
 
                 data = response.json()
+                logger.debug(f"data: {data}")
                 if not data.get("active", False):
                     return None
 

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -33,6 +33,7 @@ class SimpleTokenVerifier(TokenVerifier):
                     data={"token": token},
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                 )
+                logger.debug(f"Response to token introspection: {response}")
 
                 if response.status_code != 200:
                     logger.debug(f"Token introspection returned status {response.status_code}")

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -7,7 +7,7 @@ from mcp.server.auth.settings import AuthSettings
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format='%(levelname)s: %(message)s')
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), stream=sys.stdout, format='%(levelname)s: %(message)s')
 
 
 class SimpleTokenVerifier(TokenVerifier):

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 import httpx
 from pydantic import AnyHttpUrl

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -4,6 +4,10 @@ from pydantic import AnyHttpUrl
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format='%(levelname)s: %(message)s')
+
+
 class SimpleTokenVerifier(TokenVerifier):
     """Simple token verifier for demonstration."""
     def __init__(self, introspection_endpoint = None, client_id = None):

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import httpx
 from pydantic import AnyHttpUrl
 from mcp.server.auth.settings import AuthSettings

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -1,27 +1,81 @@
 import os
+import httpx
 from pydantic import AnyHttpUrl
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 class SimpleTokenVerifier(TokenVerifier):
     """Simple token verifier for demonstration."""
+    def __init__(self, introspection_endpoint = None, client_id = None):
+        self.introspection_endpoint = introspection_endpoint
+        self.client_id = client_id
 
-    async def verify_token(self, token: str) -> AccessToken | None:
-        print(token)
+    def _dummy_token(self, token: str) -> AccessToken | None:
         return AccessToken(
-                    token=token,
-                    client_id="hard-coded-client-id",
-                    scopes=[],
-                    expires_at=None,
-                    resource=None,  # Include resource in token
+                token=token,
+                client_id="hard-coded-client-id",
+                scopes=[],
+                expires_at=None,
+                resource=None,
                 )
 
+    def _verify_token(self, token: str) -> AccessToken | None:
+        timeout = httpx.Timeout(10.0, connect=5.0)
+        limits = httpx.Limits(max_connections=10, max_keepalive_connections=5)
+        async with httpx.AsyncClient (
+            timeout=timeout,
+            limits=limits,
+            verify=False,
+        ) as client:
+            try:
+                response = await client.post(
+                    self.introspection_endpoint,
+                    data={"token": token},
+                    headers={"Content-Type": "application/x-www-form-urlencoded"},
+                )
+
+                if response.status_code != 200:
+                    logger.debug(f"Token introspection returned status {response.status_code}")
+                    return None
+
+                data = response.json()
+                if not data.get("active", False):
+                    return None
+
+                # RFC 8707 resource validation (only when --oauth-strict is set)
+                if self.validate_resource and not self._validate_resource(data):
+                    logger.warning(f"Token resource validation failed. Expected: {self.resource_url}")
+                    return None
+
+                access_token = AccessToken(
+                    token=token,
+                    client_id=data.get("client_id", "unknown"),
+                    scopes=data.get("scope", "").split() if data.get("scope") else [],
+                    expires_at=data.get("exp"),
+                    resource=data.get("aud"),  # Include resource in token
+                )
+                logger.debug(str(access_token))
+                return access_token
+            except Exception as e:
+                logger.warning(f"Token introspection failed: {e}")
+                return None
+
+
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        logger.info(f"Received Access Token: {token}")
+        if self.client_id is None: # no verification
+            return self._dummy_token(token)
+        # if id and secret are defined, verify against issuer
+        return self._verify_token(token)
+
 def get_token_verifier():
-    issuer = os.getenv("ISSUER")
-    if issuer is None:
+    introspection_endpoint = os.getenv("INTROSPECTION_ENDPOINT")
+    client_id = os.getenv("CLIENT_NAME")
+    if introspection_endpoint is None:
         return None
     else:
-        return SimpleTokenVerifier()
+        return SimpleTokenVerifier(introspection_endpoint=introspection_endpoint, client_id=client_id)
 
 def get_auth():
     issuer = os.getenv("ISSUER")

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -22,7 +22,7 @@ class SimpleTokenVerifier(TokenVerifier):
     def _verify_token(self, token: str) -> AccessToken | None:
         timeout = httpx.Timeout(10.0, connect=5.0)
         limits = httpx.Limits(max_connections=10, max_keepalive_connections=5)
-        async with httpx.AsyncClient (
+        with httpx.AsyncClient (
             timeout=timeout,
             limits=limits,
             verify=False,

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -28,7 +28,7 @@ class SimpleTokenVerifier(TokenVerifier):
     def _verify_token(self, token: str) -> AccessToken | None:
         timeout = httpx.Timeout(10.0, connect=5.0)
         limits = httpx.Limits(max_connections=10, max_keepalive_connections=5)
-        with httpx.AsyncClient (
+        with httpx.Client (
             timeout=timeout,
             limits=limits,
             verify=False,

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -28,7 +28,7 @@ class SimpleTokenVerifier(TokenVerifier):
             verify=False,
         ) as client:
             try:
-                response = await client.post(
+                response = client.post(
                     self.introspection_endpoint,
                     data={"token": token},
                     headers={"Content-Type": "application/x-www-form-urlencoded"},

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -72,7 +72,7 @@ class SimpleTokenVerifier(TokenVerifier):
                 if not data.get("active", False):
                     return None
 
-                # RFC 8707 resource validation (only when --oauth-strict is set)
+                # RFC 8707 resource validation
                 if self.expected_audience is None:
                     logger.warning(f"No expected audience set. Skipping token resource validation")
                     if not self._validate_resource(data):
@@ -81,9 +81,10 @@ class SimpleTokenVerifier(TokenVerifier):
 
                 access_token = AccessToken(
                     token=token,
+                    client_id=data.get("client_id", "unknown"),
                     scopes=data.get("scope", "").split() if data.get("scope") else [],
                     expires_at=data.get("exp"),
-                    resource=data.get("aud"),  # Include resource in token
+                    resource=(" ".join(data.get("aud"))),  # Include resource in token
                 )
                 logger.debug(str(access_token))
                 return access_token

--- a/mcp/slack_tool/auth.py
+++ b/mcp/slack_tool/auth.py
@@ -75,9 +75,9 @@ class SimpleTokenVerifier(TokenVerifier):
                 # RFC 8707 resource validation
                 if self.expected_audience is None:
                     logger.warning(f"No expected audience set. Skipping token resource validation")
-                    if not self._validate_resource(data):
-                        logger.warning(f"Token resource validation failed. Expected: {self.expected_audience}")
-                        return None
+                elif not self._validate_resource(data):
+                    logger.warning(f"Token resource validation failed. Expected: {self.expected_audience}")
+                    return None
 
                 access_token = AccessToken(
                     token=token,

--- a/mcp/slack_tool/slack_tool.py
+++ b/mcp/slack_tool/slack_tool.py
@@ -1,9 +1,13 @@
 import os
+import logging
 from typing import List, Dict, Any
 from mcp.server.fastmcp import FastMCP
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from auth import get_token_verifier, get_auth
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format='%(levelname)s: %(message)s')
 
 # setup slack client
 SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", "YOUR_SLACK_BOT_TOKEN")

--- a/mcp/slack_tool/slack_tool.py
+++ b/mcp/slack_tool/slack_tool.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 from typing import List, Dict, Any
 from mcp.server.fastmcp import FastMCP

--- a/mcp/slack_tool/slack_tool.py
+++ b/mcp/slack_tool/slack_tool.py
@@ -8,7 +8,7 @@ from slack_sdk.errors import SlackApiError
 from auth import get_token_verifier, get_auth
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), stream=sys.stdout, format='%(levelname)s: %(message)s')
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "DEBUG"), stream=sys.stdout, format='%(levelname)s: %(message)s')
 
 # setup slack client
 SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", "YOUR_SLACK_BOT_TOKEN")

--- a/mcp/slack_tool/slack_tool.py
+++ b/mcp/slack_tool/slack_tool.py
@@ -8,7 +8,7 @@ from slack_sdk.errors import SlackApiError
 from auth import get_token_verifier, get_auth
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, stream=sys.stdout, format='%(levelname)s: %(message)s')
+logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"), stream=sys.stdout, format='%(levelname)s: %(message)s')
 
 # setup slack client
 SLACK_BOT_TOKEN = os.getenv("SLACK_BOT_TOKEN", "YOUR_SLACK_BOT_TOKEN")


### PR DESCRIPTION
This adds the option to enable OAuth security in the MCP Server. When `ISSUER` and `INTROSPECTION_ENDPOINT` are set, the server requires and validates access tokens from requests. 

Additionally, when the `AUDIENCE` variable is set, the token is checked for the given audience value. 