### PR TITLE
:wrench::bulb: Update env vars for consistency

### DIFF
--- a/a2a/weather_service/src/weather_service/__init__.py
+++ b/a2a/weather_service/src/weather_service/__init__.py
@@ -6,7 +6,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 
 def setup_tracer():
     resource = Resource.create(attributes={
-        "service.name": "acp-server",
+        "service.name": "a2a-server",
     })
     provider = TracerProvider(resource=resource)
     processor = BatchSpanProcessor(OTLPSpanExporter())

--- a/a2a/weather_service/src/weather_service/configuration.py
+++ b/a2a/weather_service/src/weather_service/configuration.py
@@ -4,4 +4,3 @@ class Configuration(BaseSettings):
     llm_model: str = "llama3.1"
     llm_api_base: str = "http://localhost:11434/v1"
     llm_api_key: str = "dummy"
-

--- a/a2a/weather_service/src/weather_service/graph.py
+++ b/a2a/weather_service/src/weather_service/graph.py
@@ -16,7 +16,7 @@ def get_mcpclient():
     return MultiServerMCPClient({
         "math": {
             "url": os.getenv("MCP_URL", "http://localhost:8000/mcp"),
-            "transport": os.getenv("ACP_MCP_TRANSPORT", "streamable_http"),
+            "transport": os.getenv("MCP_TRANSPORT", "streamable-http"),
         }
     })
 
@@ -27,7 +27,7 @@ async def get_graph(client) -> StateGraph:
         openai_api_base=config.llm_api_base,
         temperature=0,
     )
-    
+
     # Get tools asynchronously
     tools = await client.get_tools()
     llm_with_tools = llm.bind_tools(tools)

--- a/a2a/weather_service/src/weather_service/graph.py
+++ b/a2a/weather_service/src/weather_service/graph.py
@@ -16,7 +16,7 @@ def get_mcpclient():
     return MultiServerMCPClient({
         "math": {
             "url": os.getenv("MCP_URL", "http://localhost:8000/mcp"),
-            "transport": os.getenv("MCP_TRANSPORT", "streamable-http"),
+            "transport": os.getenv("MCP_TRANSPORT", "streamable_http"),
         }
     })
 

--- a/sample-environments.yaml
+++ b/sample-environments.yaml
@@ -22,7 +22,7 @@ data:
       {"name": "LLM_API_BASE", "value": "https://api.openai.com/v1"},
       {"name": "LLM_MODEL", "value": "gpt-4o-mini-2024-07-18"}
     ]
-  # mcp weather assumes we are using streamable-transport
+  # mcp weather assumes we are using streamable-http transport
   mcp-weather: |
     [
       {"name": "MCP_URL", "value": "http://weather-tool:8000/mcp"}
@@ -34,7 +34,7 @@ data:
   mcp-slack-config: |
     [
       {
-        "name": "SLACK_BOT_TOKEN", 
+        "name": "SLACK_BOT_TOKEN",
         "valueFrom": {"secretKeyRef": {"name": "slack-secret", "key": "bot-token"}}
       }
     ]


### PR DESCRIPTION
Mainly noticed `ACP_MCP_TRANSPORT` should likely be just `MCP_TRANSPORT` now. 

Perhaps related to https://github.com/kagenti/kagenti/issues/145