### PR TITLE
:sparkles: Read CLIENT_SECRET from a local file instead of Env. variable

### DIFF
--- a/a2a/slack_researcher/slack_researcher/config.py
+++ b/a2a/slack_researcher/slack_researcher/config.py
@@ -92,7 +92,7 @@ class Settings(BaseSettings):
             with open(self.secret_file_path, "r") as f:
                 self.CLIENT_SECRET = f.read().strip()
         except FileNotFoundError:
-            logging.warning("CLIENT_SECRET file not found at {self.secret_file_path}")
+            logging.warning(f"CLIENT_SECRET file not found at {self.secret_file_path}")
         except Exception as e:
             logging.error(f"Error reading CLIENT_SECRET file: {e}")
 


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
To improve a security posture, we are reading the CLIENT_SECRET from a local file instead of Env. variables

## Related issue(s)

Fixes #
