### PR TITLE
:bug: If there is a problem talking to the Weather tool, it is not shown in the UI

### DIFF
--- a/a2a/weather_service/src/weather_service/agent.py
+++ b/a2a/weather_service/src/weather_service/agent.py
@@ -123,7 +123,7 @@ class WeatherExecutor(AgentExecutor):
                 logger.info(f'Successfully connected to MCP server. Available tools: {[tool.name for tool in tools]}')
             except Exception as tool_error:
                 logger.error(f'Failed to connect to MCP server: {tool_error}')
-                await event_emitter.emit_event("Error: Cannot connect to MCP weather service at {os.getenv('MCP_URL', 'http://localhost:8000/sse')}. Please ensure the weather MCP server is running. Error: {tool_error}", failed=True)
+                await event_emitter.emit_event(f"Error: Cannot connect to MCP weather service at {os.getenv('MCP_URL', 'http://localhost:8000/sse')}. Please ensure the weather MCP server is running. Error: {tool_error}", failed=True)
                 return
 
             graph = await get_graph(mcpclient)


### PR DESCRIPTION
## Summary

If there is a problem talking to the Weather MCP server, the UI shows
`Error: Cannot connect to MCP weather service at {os.getenv('MCP_URL', '[http://localhost:8000/sse')}](http://localhost:8000/sse')%7D). Please ensure the weather MCP server is running. Error: {tool_error}`

This confused me because I had correctly defined `MCP_URL`, as verified by `oc -n team1 exec deployment/weather-service printenv | grep MCP`.  The error message does not show the actual URL value, nor the error.

## Related issue(s)
No issue created.

## Details

The log shows

```
...
DEBUG:mcp.client.streamable_http:Connecting to StreamableHTTP endpoint: http://weather-tool:8000/mcp
DEBUG:mcp.client.streamable_http:Sending client message: root=JSONRPCRequest(method='initialize', params={'protocolVersion': '2025-06-18', 'capabilities': {}, 'clientInfo': {'name': 'mcp', 'version': '0.1.0'}}, jsonrpc='2.0', id=0)
DEBUG:httpcore.connection:connect_tcp.started host='weather-tool' port=8000 local_address=None timeout=30.0 socket_options=None
DEBUG:httpcore.http11:receive_response_headers.started request=<Request [b'POST']>
DEBUG:httpcore.http11:receive_response_headers.failed exception=ReadError(BrokenResourceError())
...
ERROR:weather_service.agent:Failed to connect to MCP server: unhandled errors in a TaskGroup (1 sub-exception)
...
```

