### PR TITLE
:wrench: Update default MCP URL without toolhive

### DIFF
--- a/a2a/weather_service/.env.ollama
+++ b/a2a/weather_service/.env.ollama
@@ -1,4 +1,4 @@
 LLM_API_BASE=http://host.docker.internal:11434/v1
 LLM_API_KEY=dummy
 LLM_MODEL=llama3.2:3b-instruct-fp16
-MCP_URL=http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp
+MCP_URL=http://weather-tool-mcp:8000/mcp

--- a/a2a/weather_service/.env.openai
+++ b/a2a/weather_service/.env.openai
@@ -2,4 +2,4 @@ OPENAI_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": 
 LLM_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
 LLM_API_BASE=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini-2024-07-18
-MCP_URL=http://weather-tool-mcp.team1.svc.cluster.local:8000/mcp
+MCP_URL=http://weather-tool-mcp:8000/mcp


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The default MCP URL is updated now that the Toolhive proxy is removed. The URL can be updated from the tool URL

Post https://github.com/kagenti/kagenti/pull/588 update
