### PR TITLE
Fix Dockerfiles to use fully qualified image names for Podman compatibility

### DIFF
--- a/a2a/weather_service/Dockerfile
+++ b/a2a/weather_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM docker.io/library/python:3.12-slim-bookworm
 ARG RELEASE_VERSION="main"
 
 # Install uv

--- a/mcp/github_tool/Dockerfile
+++ b/mcp/github_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.9-bookworm
+FROM docker.io/library/golang:1.24.9-bookworm
 
 WORKDIR /app
 EXPOSE 8080

--- a/mcp/shopping_tool/Dockerfile
+++ b/mcp/shopping_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/library/python:3.11-slim
 
 WORKDIR /app
 
@@ -25,4 +25,3 @@ EXPOSE 8000
 
 # Run the server
 CMD ["python", "shopping_agent.py"]
-

--- a/mcp/weather_tool/Dockerfile
+++ b/mcp/weather_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM docker.io/library/python:3.12-slim-bookworm
 ARG RELEASE_VERSION="main"
 
 # Install uv


### PR DESCRIPTION
## Summary

- Use fully qualified image names (`docker.io/library/...`) in all Dockerfiles that previously used short names
- Fixes Shipwright builds that use Buildah/Podman, which enforce fully qualified names in non-interactive environments

## Problem

Shipwright builds fail with:
```
STEP 1/7: FROM golang:1.24.9-bookworm
Error: creating build container: short-name resolution enforced but cannot prompt without a TTY
```

## Changes

| File | Before | After |
|------|--------|-------|
| `mcp/github_tool/Dockerfile` | `golang:1.24.9-bookworm` | `docker.io/library/golang:1.24.9-bookworm` |
| `mcp/weather_tool/Dockerfile` | `python:3.12-slim-bookworm` | `docker.io/library/python:3.12-slim-bookworm` |
| `mcp/shopping_tool/Dockerfile` | `python:3.11-slim` | `docker.io/library/python:3.11-slim` |
| `a2a/weather_service/Dockerfile` | `python:3.12-slim-bookworm` | `docker.io/library/python:3.12-slim-bookworm` |

All other Dockerfiles already use fully qualified names (e.g., `ghcr.io/astral-sh/uv:...`).

Fixes #123

## Test plan

- [ ] Verify Shipwright builds succeed for `mcp/github_tool` with Podman-based build strategy
- [ ] Verify builds still work with Docker-based build strategy