### PR TITLE
🌱 Remove dependency on docker.io for base images

### DIFF
--- a/a2a/weather_service/Dockerfile
+++ b/a2a/weather_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.12-slim-bookworm
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG RELEASE_VERSION="main"
 
 # Install uv

--- a/mcp/github_tool/Dockerfile
+++ b/mcp/github_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.24.9-bookworm
+FROM public.ecr.aws/docker/library/golang:1.24.9-bookworm
 
 WORKDIR /app
 EXPOSE 8080

--- a/mcp/shopping_tool/Dockerfile
+++ b/mcp/shopping_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.11-slim
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 WORKDIR /app
 

--- a/mcp/weather_tool/Dockerfile
+++ b/mcp/weather_tool/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/python:3.12-slim-bookworm
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 ARG RELEASE_VERSION="main"
 
 # Install uv


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

We still get sporadic rate limiting on base images for our examples of agents and tools.  I verified that due to the way buildah works even preload on kind does not help, the images need to be on a real registry. This PR removes the dependency for the remaining base images still relying on docker hub.

## Related issue(s)

Fixes #
