### PR TITLE
feat: Update env files for AuthBridge demo with Secret refs

### DIFF
--- a/a2a/git_issue_agent/.env.ollama
+++ b/a2a/git_issue_agent/.env.ollama
@@ -1,10 +1,23 @@
-MCP_URL = "http://github-tool:8000/mcp"
-LOG_LEVEL = "DEBUG"
-JWKS_URI = "http://keycloak.keycloak.svc.cluster.local:8080/realms/master/protocol/openid-connect/certs"
-TASK_MODEL_ID = "ollama/ibm/granite4:latest"
-LLM_API_BASE = "http://host.docker.internal:11434"
-LLM_API_KEY = "ollama"
-MODEL_TEMPERATURE = 0
-SERVICE_PORT = 8000
-TOKEN_URL = "http://keycloak.keycloak.svc.cluster.local:8080/realms/master/protocol/openid-connect/token"
-TARGET_SCOPES = "github-full-access github-partial-access"
+# Git Issue Agent - Ollama configuration
+#
+# Uses a local Ollama instance for LLM inference.
+# Prerequisite: Ollama must be running with the model pulled:
+#   ollama pull ibm/granite4:latest
+
+# LLM configuration
+TASK_MODEL_ID=ollama/ibm/granite4:latest
+LLM_API_BASE=http://ollama.ollama.svc:11434
+LLM_API_KEY=ollama
+MODEL_TEMPERATURE=0
+
+# Agent service
+SERVICE_PORT=8000
+LOG_LEVEL=DEBUG
+
+# MCP Tool endpoint
+MCP_URL=http://github-tool-mcp:9090/mcp
+
+# Keycloak / AuthBridge token settings
+JWKS_URI=http://keycloak-service.keycloak.svc:8080/realms/demo/protocol/openid-connect/certs
+TOKEN_URL=http://keycloak-service.keycloak.svc:8080/realms/demo/protocol/openid-connect/token
+TARGET_SCOPES=github-full-access github-partial-access

--- a/a2a/git_issue_agent/.env.openai
+++ b/a2a/git_issue_agent/.env.openai
@@ -1,6 +1,23 @@
-TASK_MODEL_ID = "gpt-4.1-nano"
-MCP_URL = "http://github-tool:8000/mcp"
-LOG_LEVEL = "DEBUG"
-JWKS_URI = "http://keycloak.keycloak.svc.cluster.local:8080/realms/master/protocol/openid-connect/certs"
-TOKEN_URL = "http://keycloak.keycloak.svc.cluster.local:8080/realms/master/protocol/openid-connect/token"
-TARGET_SCOPES = "github-full-access github-partial-access"
+# Git Issue Agent - OpenAI configuration
+#
+# Uses OpenAI for LLM inference.
+# Prerequisite: Create the Kubernetes secret with your API key:
+#   kubectl create secret generic openai-secret -n team1 \
+#     --from-literal=apikey="<YOUR_OPENAI_API_KEY>"
+
+# LLM configuration
+TASK_MODEL_ID=gpt-4.1-nano
+LLM_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
+OPENAI_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
+
+# Agent service
+SERVICE_PORT=8000
+LOG_LEVEL=DEBUG
+
+# MCP Tool endpoint
+MCP_URL=http://github-tool-mcp:9090/mcp
+
+# Keycloak / AuthBridge token settings
+JWKS_URI=http://keycloak-service.keycloak.svc:8080/realms/demo/protocol/openid-connect/certs
+TOKEN_URL=http://keycloak-service.keycloak.svc:8080/realms/demo/protocol/openid-connect/token
+TARGET_SCOPES=github-full-access github-partial-access

--- a/mcp/github_tool/.env.authbridge
+++ b/mcp/github_tool/.env.authbridge
@@ -1,0 +1,18 @@
+# GitHub Tool environment variables for AuthBridge demo
+#
+# Prerequisites: Create the Kubernetes secret before deploying:
+#
+#   kubectl create secret generic github-tool-secrets -n team1 \
+#     --from-literal=INIT_AUTH_HEADER="Bearer <PRIVILEGED_ACCESS_PAT>" \
+#     --from-literal=UPSTREAM_HEADER_TO_USE_IF_IN_AUDIENCE="Bearer <PRIVILEGED_ACCESS_PAT>" \
+#     --from-literal=UPSTREAM_HEADER_TO_USE_IF_NOT_IN_AUDIENCE="Bearer <PUBLIC_ACCESS_PAT>"
+
+# GitHub PAT tokens - referenced from Kubernetes Secret "github-tool-secrets"
+INIT_AUTH_HEADER='{"valueFrom": {"secretKeyRef": {"name": "github-tool-secrets", "key": "INIT_AUTH_HEADER"}}}'
+UPSTREAM_HEADER_TO_USE_IF_IN_AUDIENCE='{"valueFrom": {"secretKeyRef": {"name": "github-tool-secrets", "key": "UPSTREAM_HEADER_TO_USE_IF_IN_AUDIENCE"}}}'
+UPSTREAM_HEADER_TO_USE_IF_NOT_IN_AUDIENCE='{"valueFrom": {"secretKeyRef": {"name": "github-tool-secrets", "key": "UPSTREAM_HEADER_TO_USE_IF_NOT_IN_AUDIENCE"}}}'
+
+# Keycloak validation settings for incoming tokens
+ISSUER=http://keycloak.localtest.me:8080/realms/demo
+JWKS_URL=http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/certs
+AUDIENCE=github-tool


### PR DESCRIPTION
## Summary

- Updates `.env.ollama` and `.env.openai` for the git issue agent with AuthBridge demo values (demo realm, correct service endpoints, structured comments)
- Adds `.env.authbridge` for the GitHub tool with Kubernetes Secret references for PAT tokens and Keycloak validation settings
- Env files use the extended `.env` format with `valueFrom` Secret references, compatible with the Kagenti UI env var import feature ([kagenti/kagenti#705](https://github.com/kagenti/kagenti/pull/705))

These files are referenced by the [AuthBridge GitHub Issue demo guide](https://github.com/kagenti/kagenti-extensions/blob/main/AuthBridge/demos/github-issue/demo-ui.md) in kagenti-extensions.

## Test plan

- [ ] Import `.env.ollama` via Kagenti UI Import Agent > Import from File/URL — verify all variables populate correctly
- [ ] Import `.env.openai` via Kagenti UI — verify Secret type entries appear for `LLM_API_KEY` and `OPENAI_API_KEY`
- [ ] Import `.env.authbridge` via Kagenti UI Import Tool > Import from File/URL — verify Secret type entries for PAT tokens and direct values for Keycloak settings
- [ ] Deploy agent + tool using imported env vars and verify AuthBridge token exchange works end-to-end

Made with [Cursor](https://cursor.com)