### PR TITLE
fix: default LLM_API_BASE to host.docker.internal for local Ollama

### DIFF
--- a/a2a/git_issue_agent/.env.ollama
+++ b/a2a/git_issue_agent/.env.ollama
@@ -6,7 +6,9 @@
 
 # LLM configuration
 TASK_MODEL_ID=ollama/ibm/granite4:latest
-LLM_API_BASE=http://ollama.ollama.svc:11434
+# Default: local Ollama via Kind/Docker Desktop host gateway.
+# For in-cluster Ollama: LLM_API_BASE=http://ollama.ollama.svc:11434
+LLM_API_BASE=http://host.docker.internal:11434
 LLM_API_KEY=ollama
 MODEL_TEMPERATURE=0
 


### PR DESCRIPTION
## Summary

Changes the default `LLM_API_BASE` in the git issue agent's `.env.ollama` from `ollama.ollama.svc:11434` (in-cluster) to `host.docker.internal:11434` (host machine). Most developers run Ollama locally via `ollama serve` with Kind/Docker Desktop, so the previous default caused connection failures out of the box.

The in-cluster alternative is documented as a comment for users who deploy Ollama inside Kubernetes.

## Test plan

- [ ] Import agent via Kagenti UI using `.env.ollama` from URL
- [ ] Verify `LLM_API_BASE` is set to `http://host.docker.internal:11434`
- [ ] With local `ollama serve` running, query the agent successfully from a test-client pod
