### PR TITLE
fix: update github-tool .env.authbridge from demo to kagenti realm

### DIFF
--- a/mcp/github_tool/.env.authbridge
+++ b/mcp/github_tool/.env.authbridge
@@ -13,6 +13,6 @@ UPSTREAM_HEADER_TO_USE_IF_IN_AUDIENCE='{"valueFrom": {"secretKeyRef": {"name": "
 UPSTREAM_HEADER_TO_USE_IF_NOT_IN_AUDIENCE='{"valueFrom": {"secretKeyRef": {"name": "github-tool-secrets", "key": "UPSTREAM_HEADER_TO_USE_IF_NOT_IN_AUDIENCE"}}}'
 
 # Keycloak validation settings for incoming tokens
-ISSUER=http://keycloak.localtest.me:8080/realms/demo
-JWKS_URL=http://keycloak-service.keycloak.svc.cluster.local:8080/realms/demo/protocol/openid-connect/certs
+ISSUER=http://keycloak.localtest.me:8080/realms/kagenti
+JWKS_URL=http://keycloak-service.keycloak.svc.cluster.local:8080/realms/kagenti/protocol/openid-connect/certs
 AUDIENCE=github-tool


### PR DESCRIPTION
## Summary

- Update `ISSUER` and `JWKS_URL` in `mcp/github_tool/.env.authbridge` from `realms/demo` to `realms/kagenti`
- Aligns with the platform-wide realm migration (kagenti/kagenti#764)
- Without this fix, UI-based tool imports use the wrong realm for token validation, causing the tool to reject valid tokens

### Files changed

| File | Changes |
|------|---------|
| `mcp/github_tool/.env.authbridge` | ISSUER and JWKS_URL: `realms/demo` → `realms/kagenti` |

Part of: kagenti/kagenti#767

## Test plan

- [ ] Import GitHub tool via Kagenti UI using **From URL** with the updated `.env.authbridge`
- [ ] Verify tool validates tokens from the `kagenti` realm correctly
- [ ] Verify AuthBridge token exchange flow works end-to-end