### PR TITLE
Feat: Example env var files for OpenAI and ollama

### DIFF
--- a/a2a/simple_generalist/.env.ollama
+++ b/a2a/simple_generalist/.env.ollama
@@ -1,0 +1,30 @@
+LOG_LEVEL=INFO
+# LOG_LEVEL=DEBUG
+
+MCP_SERVER_URL=http://appworld-apis-mcp:8001/mcp/
+
+# LLM Configuration
+LLM_MODEL=gpt-oss:latest
+# LLM_MODEL=gpt-4
+LLM_API_KEY=dummy
+# Use the next line for OpenaI
+# LLM_API_BASE=https://api.openai.com/v1
+LLM_API_BASE=http://host.docker.internal:11434/v1
+OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+
+# LLM Parameters
+# LLM_TEMPERATURE=0.0
+
+# Execution Limits
+MAX_ITERATIONS=20
+
+# Public URL advertised in Agent Card (optional)
+# A2A_PUBLIC_URL=http://localhost:8000/
+# # For Kagenti kind install, external to cluster
+A2A_PUBLIC_URL=http://simple-generalist.team1.localtest.me:8080
+# For Kubernetes or OpenShift, internal to cluster
+# A2A_PUBLIC_URL=http://simple-generalist.team1.localtest.me:8080/
+
+# Tracing
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317  # OTLP gRPC endpoint (e.g. Jaeger, Grafana Tempo)
+# OTEL_CONSOLE_TRACING=false  # Print traces to console when no OTLP endpoint is set

--- a/a2a/simple_generalist/.env.openai
+++ b/a2a/simple_generalist/.env.openai
@@ -1,0 +1,31 @@
+LOG_LEVEL=INFO
+# LOG_LEVEL=DEBUG
+
+MCP_SERVER_URL=http://appworld-apis-mcp:8001/mcp/
+
+# LLM Configuration
+# LLM_MODEL=gpt-oss:latest
+LLM_MODEL=gpt-4
+LLM_API_KEY=your-api-key-here
+# LLM_API_BASE=https://api.openai.com/v1
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# Use the next two lines for ollama on Mac via Podman or Docker
+# LLM_API_BASE=http://host.docker.internal:11434/v1
+# OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+
+# LLM Parameters
+# LLM_TEMPERATURE=0.0
+
+# Execution Limits
+MAX_ITERATIONS=20
+
+# Public URL advertised in Agent Card (optional)
+# A2A_PUBLIC_URL=http://localhost:8000/
+# # For Kagenti kind install, external to cluster
+A2A_PUBLIC_URL=http://simple-generalist.team1.localtest.me:8080
+# For Kubernetes or OpenShift, internal to cluster
+# A2A_PUBLIC_URL=http://simple-generalist.team1.localtest.me:8080/
+
+# Tracing
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317  # OTLP gRPC endpoint (e.g. Jaeger, Grafana Tempo)
+# OTEL_CONSOLE_TRACING=false  # Print traces to console when no OTLP endpoint is set

--- a/a2a/simple_generalist/README.md
+++ b/a2a/simple_generalist/README.md
@@ -1,8 +1,8 @@
 # Simple Generalist Agent
 
-This service exposes an A2A-compatible agent server that runs an AG2 agent and can optionally use MCP tools.
+This service exposes an A2A-compatible agent server that runs an [AG2](https://pypi.org/project/ag2/) agent and can optionally use MCP tools.
 
-It was created to test the AppWorld MCP server. The agent prompt in `src/simple_generalist/agent/prompts.py` is geared toward using AppWorld as the MCP server.
+It was created to test the [AppWorld](https://github.com/StonyBrookNLP/appworld) MCP server. The agent prompt in `src/simple_generalist/agent/prompts.py` is geared toward using AppWorld as the MCP server.
 
 ## What It Actually Does
 


### PR DESCRIPTION
This PR gives example environment variables for the generalist_agent.

The _.env.openai_ file allows us to add the generalist_agent to the list of Kagenti examples presented by the UI.
The ollama variant was helpful for me during testing.  This example needed configuration that wasn't obvious to me.
