### PR TITLE
Feat: Add issue self-assign caller workflow

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,22 @@
+# Issue Self-Assign
+#
+# Thin caller for the org-wide reusable self-assign workflow.
+# Configuration and defaults are managed centrally in kagenti/.github.
+#
+# Reference: https://github.com/kagenti/.github/blob/main/.github/workflows/self-assign-reusable.yml
+#
+name: Issue self-assign
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  self-assign:
+    uses: kagenti/.github/.github/workflows/self-assign-reusable.yml@main
+    secrets:
+      ISSUE_ASSIGN_TOKEN: ${{ secrets.ISSUE_ASSIGN_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,5 +14,9 @@ Please follow the [Contribution guide](https://github.com/kagenti/kagenti/blob/m
 
 Please follow our [Developer's Guide](https://github.com/kagenti/kagenti/blob/main/docs/dev-guide.md#developers-guide), as found in the Kagenti Repository, where you can find comprehensive instructions for common development operations.
 
-Please note that the section concerning pre-commit does not apply to this repository. 
+Please note that the section concerning pre-commit does not apply to this repository.
+
+## Claiming an Issue
+
+Comment `/claim` on an issue to have it automatically assigned to you. Issues labeled `blocked` or `in-progress` cannot be claimed this way. If you need to release an issue, comment `/unassign` or ask a maintainer.
 


### PR DESCRIPTION
## Summary
- Adds caller workflow for org-wide issue self-assign (`/claim`)
- Updates CONTRIBUTING.md with `/claim` instructions

## Test plan
- [ ] Depends on kagenti/.github reusable workflow being merged first
- [ ] Comment `/claim` on an issue from a non-member account
- [ ] Verify assignment and bot reply