### PR TITLE
fix: Strip nil arguments before forwarding MCP tool calls to upstream

### DIFF
--- a/mcp/github_tool/gtlib/upstream.go
+++ b/mcp/github_tool/gtlib/upstream.go
@@ -225,12 +225,28 @@ func (m *mcpAuthImpl) CallTool(
 		m.serverSessions[downstreamSession] = upstreamSession
 	}
 
+	if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+		stripNilArguments(args)
+	}
+
 	res, err := upstreamSession.client.CallTool(ctx, request)
 	if err != nil {
 		upstreamSession.lastContact = time.Now()
 	}
 
 	return res, err
+}
+
+// stripNilArguments removes nil-valued entries from tool call arguments.
+// OpenAI's function calling API sends explicit JSON null for optional
+// parameters, but the upstream GitHub MCP server rejects nil where it
+// expects a typed value.
+func stripNilArguments(args map[string]interface{}) {
+	for k, v := range args {
+		if v == nil {
+			delete(args, k)
+		}
+	}
 }
 
 func (m *mcpAuthImpl) createUpstreamSession(ctx context.Context, authorization string, options ...transport.StreamableHTTPCOption) (*upstreamSessionState, error) {


### PR DESCRIPTION
## Summary

- Strip nil-valued entries from tool call arguments before forwarding to the upstream GitHub MCP server
- OpenAI function calling sends explicit JSON `null` for optional parameters, but the upstream MCP server rejects `nil` where it expects a typed value

## Problem

Every `list_issues` call fails with errors like:
```
parameter state is not of type string, is <nil>
```

The LLM retries with progressively more fields filled in, but each attempt fails on the next `null` field until retries are exhausted.

## Fix

Added `stripNilArguments()` in `CallTool()` that removes nil-valued entries from the arguments map before forwarding to the upstream MCP server.

## Test plan

- [x] Built and deployed locally to Kind cluster
- [x] Verified end-to-end: Alice token → inbound validation → token exchange → MCP tool call → GitHub issues returned successfully

Fixes #175