### PR TITLE
fix: Add LLM_API_BASE and fix model name in git-issue-agent .env.openai

### DIFF
--- a/a2a/git_issue_agent/.env.openai
+++ b/a2a/git_issue_agent/.env.openai
@@ -6,7 +6,8 @@
 #     --from-literal=apikey="<YOUR_OPENAI_API_KEY>"
 
 # LLM configuration
-TASK_MODEL_ID=gpt-4.1-nano
+TASK_MODEL_ID=gpt-4o-mini
+LLM_API_BASE=https://api.openai.com/v1
 LLM_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
 OPENAI_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
 


### PR DESCRIPTION
## Summary

- Add missing `LLM_API_BASE=https://api.openai.com/v1` to `.env.openai`
- Replace `gpt-4.1-nano` with `gpt-4o-mini` for broader compatibility

## Problem

The agent's `config.py` defaults `LLM_API_BASE` to `http://host.docker.internal:11434` (Ollama) when the env var is not set. Without `LLM_API_BASE` in `.env.openai`, all OpenAI model requests are sent to the Ollama endpoint and fail with 404:

```
httpx.HTTPStatusError: Client error '404 Not Found' for url 'http://host.docker.internal:11434/chat/completions'
```

## Test plan

- [x] Deployed agent with patched env vars via `kubectl set env`
- [x] Verified OpenAI API calls reach `api.openai.com` (200 OK in agent logs)
- [x] Verified end-to-end tool execution with `gpt-4o` and `gpt-4o-mini`

Fixes #174