### PR TITLE
Bug fix: Fix the Git Service when running on Ollama

### DIFF
--- a/a2a/git_issue_agent/.env.ollama
+++ b/a2a/git_issue_agent/.env.ollama
@@ -5,12 +5,12 @@
 #   ollama pull ibm/granite4:latest
 
 # LLM configuration
-TASK_MODEL_ID=ollama_chat/ibm/granite4:latest
+TASK_MODEL_ID=gpt-oss:latest
 # Ollama API base URL. Required by litellm (used by crewai >=1.10).
-# For Docker Desktop / Kind: http://host.docker.internal:11434
-# For in-cluster Ollama:     http://ollama.ollama.svc:11434
-LLM_API_BASE=http://host.docker.internal:11434
-OLLAMA_API_BASE=http://host.docker.internal:11434
+# For Docker Desktop / Kind: http://host.docker.internal:11434/v1
+# For in-cluster Ollama:     http://ollama.ollama.svc:11434/v1
+LLM_API_BASE=http://host.docker.internal:11434/v1
+OLLAMA_API_BASE=http://host.docker.internal:11434/v1
 LLM_API_KEY=ollama
 MODEL_TEMPERATURE=0
 
@@ -19,4 +19,5 @@ SERVICE_PORT=8000
 LOG_LEVEL=DEBUG
 
 # MCP Tool endpoint
-MCP_URL=http://github-tool-mcp:9090/mcp
+# Port 8000 is the default for Kagenti Tools
+MCP_URL=http://github-tool-mcp:8000/mcp

--- a/a2a/git_issue_agent/.env.ollama
+++ b/a2a/git_issue_agent/.env.ollama
@@ -2,15 +2,16 @@
 #
 # Uses a local Ollama instance for LLM inference.
 # Prerequisite: Ollama must be running with the model pulled:
-#   ollama pull ibm/granite4:latest
+#   ollama pull gpt-oss:latest
 
 # LLM configuration
 TASK_MODEL_ID=gpt-oss:latest
 # Ollama API base URL. Required by litellm (used by crewai >=1.10).
 # For Docker Desktop / Kind: http://host.docker.internal:11434/v1
 # For in-cluster Ollama:     http://ollama.ollama.svc:11434/v1
+# (This line matches all the other LLM_API_BASE examples in this repo)
 LLM_API_BASE=http://host.docker.internal:11434/v1
-OLLAMA_API_BASE=http://host.docker.internal:11434/v1
+# The API key is a dummy; ollama doesn't use it
 LLM_API_KEY=ollama
 MODEL_TEMPERATURE=0
 


### PR DESCRIPTION
## Summary

We supply a configuration for the Git Service when running on Kagenti under Ollama, but it doesn't work.

For example, the chat query `What do you think about https://github.com/kagenti/agent-examples/issues/218 ?` yields

```
Thought: The user query involves retrieving issues from a specific GitHub repository and issue number. Action: list_issues Action Input: {"owner":"kagenti","repo":"agent-examples","state":"all"}
```

The default port for an MCP tool in Kagenti is 8000, but this Agent example assumes the MCP server will be deployed on 9090.

## (Optional) Testing Instructions

1. Deploy the Git Tool
2. http://kagenti-ui.localtest.me:8080/agents/import
- Deploy from Existing Image, 
- ghcr.io/kagenti/agent-examples/git_issue_agent
- tag v0.1.0-alpha.8
- Env vars https://raw.githubusercontent.com/kagenti/agent-examples/refs/heads/main/a2a/git_issue_agent/.env.ollama
  - Override the values with the changes in this PR
- Deploy
- Wait for agent to become Ready
