### PR TITLE
fix(a2a): await enqueue_event calls in agent executors

### DIFF
--- a/a2a/a2a_contact_extractor/agent_executor.py
+++ b/a2a/a2a_contact_extractor/agent_executor.py
@@ -71,7 +71,7 @@ class ExtractorAgentExecutor(AgentExecutor):
                 )
 
             if require_user_input:
-                event_queue.enqueue_event(
+                await event_queue.enqueue_event(
                     TaskStatusUpdateEvent(
                         status=TaskStatus(
                             state=TaskState.input_required,
@@ -87,7 +87,7 @@ class ExtractorAgentExecutor(AgentExecutor):
                     )
                 )
             elif is_task_complete:
-                event_queue.enqueue_event(
+                await event_queue.enqueue_event(
                     TaskArtifactUpdateEvent(
                         append=False,
                         contextId=task.context_id,
@@ -96,7 +96,7 @@ class ExtractorAgentExecutor(AgentExecutor):
                         artifact=artifact,
                     )
                 )
-                event_queue.enqueue_event(
+                await event_queue.enqueue_event(
                     TaskStatusUpdateEvent(
                         status=TaskStatus(state=TaskState.completed),
                         final=True,
@@ -105,7 +105,7 @@ class ExtractorAgentExecutor(AgentExecutor):
                     )
                 )
             else:
-                event_queue.enqueue_event(
+                await event_queue.enqueue_event(
                     TaskStatusUpdateEvent(
                         status=TaskStatus(
                             state=TaskState.working,

--- a/a2a/a2a_currency_converter/app/agent_executor.py
+++ b/a2a/a2a_currency_converter/app/agent_executor.py
@@ -51,7 +51,7 @@ class CurrencyAgentExecutor(AgentExecutor):
         if not task:
             task = new_task(context.message)
             logger.info(f"Created task for message : {context.message}")
-            event_queue.enqueue_event(task)
+            await event_queue.enqueue_event(task)
         updater = TaskUpdater(event_queue, task.id, task.context_id)
         try:
             async for item in self.agent.stream(query, task.context_id):


### PR DESCRIPTION
## Summary

- Add missing `await` to `enqueue_event()` calls in `a2a_contact_extractor` (4 call sites) and `a2a_currency_converter` (1 call site)
- Without `await`, these coroutines were silently garbage-collected, dropping A2A streaming events (artifact updates, status transitions)
- The agent processed requests correctly but the UI never received the response — only the initial `submitted` state got through

## Root Cause

`EventQueue.enqueue_event()` is an async coroutine. Calling it without `await` creates an unawaited coroutine that Python silently discards (with a `RuntimeWarning`). This meant:

1. `TaskArtifactUpdateEvent` (the actual response data) — **dropped**
2. `TaskStatusUpdateEvent` with `state=completed` — **dropped**
3. Only the initial task with `state=submitted` (which was correctly awaited) reached the UI

## Test plan

- [x] Verified on Kind cluster: agent now streams 3 SSE events (`submitted` → `artifact-update` → `completed`) vs 1 before the fix
- [x] Confirmed `RuntimeWarning: coroutine 'enqueue_event' was never awaited` no longer appears in agent logs
- [x] End-to-end UI chat test passes — response displays correctly in the Kagenti UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)