### PR TITLE
CI: Add PR title verifier workflow

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   verify:
-    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@ae31c56d344b1efc6ef174338c488b1e355649bc
+    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@fccbcfaaadf24f180b4a754377ceff6d9e000297
 

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,0 +1,10 @@
+name: PR Verifier
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  verify:
+    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@main
+

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   verify-pr-title:
     uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@4e535f2436d167295d39d488ce5c44b5a2d49792

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -5,5 +5,5 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 jobs:
-  verify:
-    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@fccbcfaaadf24f180b4a754377ceff6d9e000297
+  verify-pr-title:
+    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@4e535f2436d167295d39d488ce5c44b5a2d49792

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   verify:
-    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@main
+    uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@ae31c56d344b1efc6ef174338c488b1e355649bc
 

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -7,4 +7,3 @@ on:
 jobs:
   verify:
     uses: kagenti/.github/.github/workflows/pr-verifier-required.yml@fccbcfaaadf24f180b4a754377ceff6d9e000297
-

--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -1,3 +1,10 @@
+# PR Verifier — caller workflow
+#
+# Invokes the org-level reusable PR title verifier defined in
+# kagenti/.github to enforce PR title prefix conventions (Feat,
+# Fix, Docs, etc.) on every pull request. Pinned to a SHA for
+# supply-chain hygiene; bump intentionally when upstream changes.
+
 name: PR Verifier
 
 on:


### PR DESCRIPTION
## Summary
- Adds a caller workflow that invokes the org-level reusable PR title verifier from `kagenti/.github`
- Enforces PR title prefix conventions (Feat, Fix, Docs, etc.) on all pull requests
- No changes to existing workflows or repo configuration