### PR TITLE
fix: Update MCP_URL to use default Kagenti service port 9090

### DIFF
--- a/a2a/git_issue_agent/.env.ollama
+++ b/a2a/git_issue_agent/.env.ollama
@@ -20,5 +20,5 @@ PORT=8000
 LOG_LEVEL=DEBUG
 
 # MCP Tool endpoint
-# Port 8000 is the default for Kagenti Tools
-MCP_URL=http://github-tool-mcp:8000/mcp
+# Port 9090 is the default Kagenti service port for tools
+MCP_URL=http://github-tool-mcp:9090/mcp

--- a/a2a/image_service/.env.openai
+++ b/a2a/image_service/.env.openai
@@ -2,4 +2,4 @@ OPENAI_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": 
 LLM_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
 LLM_API_BASE=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini-2024-07-18
-MCP_URL=http://image-tool-mcp:8000/mcp
+MCP_URL=http://image-tool-mcp:9090/mcp

--- a/a2a/weather_service/.env.ollama
+++ b/a2a/weather_service/.env.ollama
@@ -1,4 +1,4 @@
 LLM_API_BASE=http://host.docker.internal:11434/v1
 LLM_API_KEY=dummy
 LLM_MODEL=llama3.2:3b-instruct-fp16
-MCP_URL=http://weather-tool-mcp:8000/mcp
+MCP_URL=http://weather-tool-mcp:9090/mcp

--- a/a2a/weather_service/.env.openai
+++ b/a2a/weather_service/.env.openai
@@ -2,4 +2,4 @@ OPENAI_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": 
 LLM_API_KEY='{"valueFrom": {"secretKeyRef": {"name": "openai-secret", "key": "apikey"}}}'
 LLM_API_BASE=https://api.openai.com/v1
 LLM_MODEL=gpt-4o-mini-2024-07-18
-MCP_URL=http://weather-tool-mcp:8000/mcp
+MCP_URL=http://weather-tool-mcp:9090/mcp


### PR DESCRIPTION
## Summary

- Updates MCP_URL in all agent .env files from port 8000 to 9090

## Root cause

The Kagenti UI changed the default tool service port from 8000 to 9090 in kagenti/kagenti#1175, but these .env files still referenced port 8000. When agents are deployed using these env files, they try to connect to the tool's K8s service on port 8000 which doesn't exist — the service listens on 9090.

## Files changed

- `a2a/weather_service/.env.ollama`
- `a2a/weather_service/.env.openai`
- `a2a/git_issue_agent/.env.ollama`
- `a2a/image_service/.env.openai`

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>