### PR TITLE
:wrench: Update dependabot Python ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
 
   # Python dependencies — A2A agents
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/a2a_contact_extractor
     schedule:
       interval: weekly
@@ -15,85 +15,85 @@ updates:
       - dependency-name: marvin
         # marvin>=3.2.0 is pinned for pydantic-ai compatibility;
         # major bumps need manual testing before merge
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/a2a_currency_converter
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/cheerup_agent
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/file_organizer
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/generic_agent
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/git_issue_agent
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/image_service
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/recipe_agent
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/reservation_service
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/simple_generalist
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/slack_researcher
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/trivia_agent
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /a2a/weather_service
     schedule:
       interval: weekly
 
   # Python dependencies — MCP tools
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/cloud_storage_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/flight_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/image_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/movie_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/reservation_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/shopping_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/slack_tool
     schedule:
       interval: weekly
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /mcp/weather_tool
     schedule:
       interval: weekly


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review [CONTRIBUTING.MD](https://github.com/kagenti/kagenti/blob/main/CONTRIBUTING.md).

// Begin modifications with assistance from Copilot
╔══════════════════════════════════════════════════════════════╗
║                   PR TITLE REQUIREMENTS                      ║
╚══════════════════════════════════════════════════════════════╝

Your PR title must follow the organization-wide enforced rules.
These rules are validated by a required workflow and enforced
via GitHub Repository Rulesets, which can block a PR from merging
if the title does not meet the prefix or formatting requirements.

✔ Allowed prefixes (must be EXACT, case-sensitive):

  Build, Chore, CI, Docs, Feat, Fix, Perf, Refactor, Revert, Style, Test,
  Feature, Bug fix, Proposal, Breaking change, Other/Misc

✔ Formatting rules:

  - Prefix must appear at the **very start** of the title.
  - Prefix must match EXACT CASE (this is enforced by our PR Title
    workflow, which validates exact-match prefixes via the
    `allowed_prefixes` input of the GitHub Action used). [3](https://kitemetric.com/blogs/automate-github-actions-updates-organization-wide-efficiency)
  - Title must be **at least 8 characters long** (enforced by the workflow).
  - Use a colon or a space after the prefix (e.g., `Feat: Add feature`).

If your PR title doesn't meet these rules, the required workflow
will fail and merging will be blocked until fixed.

// End modifications with assistance from Copilot

-->
## Summary

Dependabot's pip ecosystem updates pyproject.toml but doesn't touch uv.lock. This causes the test-startup CI to fail on every dependabot PR: uv run --locked sees the lock file out of sync with the updated constraint and refuses to run, so the agent never starts.

Open dependabot PRs will still have stale uv.lock files. We can close and let dependabot re-open them after this PR lands.


Assisted-By: Claude (Anthropic AI) [noreply@anthropic.com](mailto:noreply@anthropic.com)