### PR TITLE
chore(deps): Bump requests from 2.34.1 to 2.34.2 across services

### DIFF
--- a/a2a/weather_service/pyproject.toml
+++ b/a2a/weather_service/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "mako>=1.3.11",             # Indirect; prevents CVE-2026-41205
     "marshmallow>=3.26.2",      # Indirect; prevents CVE-2025-68480
     "python-dotenv>=1.2.2",     # Indirect; prevents CVE-2026-28684
-    "requests>=2.34.0",         # Indirect; prevents CVE-2026-25645
+    "requests>=2.34.2",         # Indirect; prevents CVE-2026-25645
 ]
 
 [project.scripts]

--- a/a2a/weather_service/uv.lock
+++ b/a2a/weather_service/uv.lock
@@ -3055,7 +3055,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3063,9 +3063,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -3684,7 +3684,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-keycloak", specifier = ">=7.1.1" },
     { name = "python-multipart", specifier = ">=0.0.28" },
-    { name = "requests", specifier = ">=2.34.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]

--- a/mcp/image_tool/pyproject.toml
+++ b/mcp/image_tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP tool for returning images from picsum.photos"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "requests>=2.34.0",
+    "requests>=2.34.2",
     "authlib>=1.7.2",   # Indirect; prevents CVE-2026-27962
     "urllib3>=2.7.0",   # Indirect; prevents CVE-2025-66418
     "fastmcp>=3.2.4",           # Indirect; prevents CVE-2026-32871 (critical), CVE-2026-27124 (high)

--- a/mcp/image_tool/uv.lock
+++ b/mcp/image_tool/uv.lock
@@ -563,7 +563,7 @@ dependencies = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.7.2" },
     { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "requests", specifier = ">=2.34.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1159,7 +1159,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1167,9 +1167,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]

--- a/mcp/movie_tool/pyproject.toml
+++ b/mcp/movie_tool/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "fastmcp>=3.2.4",           # Indirect; prevents CVE-2026-32871 (critical), CVE-2026-27124 (high)
-    "requests>=2.34.0",
+    "requests>=2.34.2",
     "authlib>=1.7.2",   # Indirect; prevents CVE-2026-27962
 ]

--- a/mcp/movie_tool/uv.lock
+++ b/mcp/movie_tool/uv.lock
@@ -498,7 +498,7 @@ dependencies = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.7.2" },
     { name = "fastmcp", specifier = ">=3.2.4" },
-    { name = "requests", specifier = ">=2.34.0" },
+    { name = "requests", specifier = ">=2.34.2" },
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1161,9 +1161,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]

--- a/mcp/shopping_tool/pyproject.toml
+++ b/mcp/shopping_tool/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "google-search-results>=2.4.2",
-    "requests>=2.34.0",
+    "requests>=2.34.2",
     "fastmcp>=3.2.4",           # Indirect; prevents CVE-2026-32871
 ]
 

--- a/mcp/slack_tool/pyproject.toml
+++ b/mcp/slack_tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "simple slack tool"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "requests>=2.34.0",
+    "requests>=2.34.2",
     "slack_sdk>=3.41.0",
     "authlib>=1.7.2",   # Indirect; prevents CVE-2026-27962
     "urllib3>=2.7.0",   # Indirect; prevents CVE-2025-66418

--- a/mcp/slack_tool/uv.lock
+++ b/mcp/slack_tool/uv.lock
@@ -472,7 +472,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7,<47" },
     { name = "fastmcp", specifier = ">=3.2.4" },
     { name = "python-multipart", specifier = ">=0.0.28" },
-    { name = "requests", specifier = ">=2.34.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "slack-sdk", specifier = ">=3.41.0" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -1106,7 +1106,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1114,9 +1114,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]

--- a/mcp/weather_tool/pyproject.toml
+++ b/mcp/weather_tool/pyproject.toml
@@ -5,7 +5,7 @@ description = "simple weather tool"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "requests>=2.34.0",
+    "requests>=2.34.2",
     "authlib>=1.7.2",   # Indirect; prevents CVE-2026-27962
     "urllib3>=2.7.0",   # Indirect; prevents CVE-2025-66418
     "python-multipart>=0.0.28", # Indirect; prevents CVE-2026-24486

--- a/mcp/weather_tool/uv.lock
+++ b/mcp/weather_tool/uv.lock
@@ -521,7 +521,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
     { name = "python-multipart", specifier = ">=0.0.28" },
-    { name = "requests", specifier = ">=2.34.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "uvicorn", specifier = ">=0.46.0" },
@@ -1279,7 +1279,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.34.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1287,9 +1287,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/36/7180e7f077c38108945dbbdf60fe04db681c3feb6e96419f8c6dc8723741/requests-2.34.1.tar.gz", hash = "sha256:0fc5669f2b69704449fe1552360bd2a73a54512dfd03e65529157f1513322beb", size = 142783, upload-time = "2026-05-13T19:20:24.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5a/4a949d170476de3c04ac036b5466422fbcbf348a917d8042eedf2cac7d1b/requests-2.34.1-py3-none-any.whl", hash = "sha256:bf38a3ff993960d3dd819c08862c40b3c703306eb7c744fcd9f4ddbb95b548f0", size = 73085, upload-time = "2026-05-13T19:20:22.827Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundles six Dependabot PRs that all bump `requests` to `2.34.2` (patch).

Bundled PRs:
- #410 — mcp/shopping_tool (range update)
- #415 — mcp/slack_tool
- #419 — mcp/weather_tool
- #421 — mcp/image_tool
- #431 — mcp/movie_tool
- #434 — a2a/weather_service

## Test plan

- [ ] CI passes
- [ ] Originals closed once this merges

Assisted-By: Claude Code