### PR TITLE
Add configurable MCP_TIMEOUT (default 600s) across all agents

### DIFF
--- a/a2a/generic_agent/src/generic_agent/config.py
+++ b/a2a/generic_agent/src/generic_agent/config.py
@@ -7,6 +7,7 @@ class Configuration(BaseSettings):
     LLM_API_KEY: str = "dummy"
     MCP_URLS: str = "http://localhost:8000/mcp"
     MCP_TRANSPORT: str = "streamable_http"
+    MCP_TIMEOUT: int = 600
     MAX_EVENT_DISPLAY_LENGTH: int = 256
     AGENT_VERSION: str = "1.0.0"
     SKILL_FOLDERS: str = "/app/skills/"

--- a/a2a/generic_agent/src/generic_agent/graph.py
+++ b/a2a/generic_agent/src/generic_agent/graph.py
@@ -48,6 +48,7 @@ def get_mcpclient() -> MultiServerMCPClient:
         client_configs[f"mcp{i}"] = {
             "url": url,
             "transport": transport,
+            "timeout": config.MCP_TIMEOUT,
         }
 
     if not client_configs:

--- a/a2a/git_issue_agent/a2a_agent.py
+++ b/a2a/git_issue_agent/a2a_agent.py
@@ -176,7 +176,7 @@ class GithubExecutor(AgentExecutor):
                     "transport": "streamable-http",
                     "headers": headers,
                 }
-                with MCPServerAdapter(server_params, connect_timeout=60) as mcp_tools:
+                with MCPServerAdapter(server_params, connect_timeout=settings.MCP_TIMEOUT) as mcp_tools:
                     # Keep only search and list issue-related tools.
                     issue_tools = [
                         tool

--- a/a2a/git_issue_agent/git_issue_agent/config.py
+++ b/a2a/git_issue_agent/git_issue_agent/config.py
@@ -29,6 +29,10 @@ class Settings(BaseSettings):
     MCP_URL: str = Field(
         os.getenv("MCP_URL", "https://api.githubcopilot.com/mcp/"), description="Endpoint for an option MCP server"
     )
+    MCP_TIMEOUT: int = Field(os.getenv("MCP_TIMEOUT", 600), description="Timeout in seconds for MCP server connection")
+
+    # auth variables for token validation
+    ISSUER: Optional[str] = Field(os.getenv("ISSUER", None), description="The issuer for incoming JWT tokens")
     SERVICE_PORT: int = Field(os.getenv("PORT", 8000), description="Port on which the service will run.")
     GITHUB_TOKEN: Optional[str] = Field(
         os.getenv("GITHUB_TOKEN", None),

--- a/a2a/simple_generalist/src/simple_generalist/a2a_server/server.py
+++ b/a2a/simple_generalist/src/simple_generalist/a2a_server/server.py
@@ -173,8 +173,8 @@ class SimpleGeneralistExecutor(AgentExecutor):
                 async with (
                     streamablehttp_client(
                         url=mcp_url,
-                        timeout=30,
-                        sse_read_timeout=300,
+                        timeout=self.settings.MCP_TIMEOUT,
+                        sse_read_timeout=self.settings.MCP_TIMEOUT,
                     ) as (
                         read_stream,
                         write_stream,

--- a/a2a/simple_generalist/src/simple_generalist/config/settings.py
+++ b/a2a/simple_generalist/src/simple_generalist/config/settings.py
@@ -36,6 +36,10 @@ class Settings(BaseSettings):
         description="MCP server URL",
         validation_alias=AliasChoices("MCP_SERVER_URL", "MCP_SERVERS"),
     )
+    MCP_TIMEOUT: int = Field(
+        default=int(os.getenv("MCP_TIMEOUT", "600")),
+        description="Timeout in seconds for MCP server connection",
+    )
 
     # LLM Configuration
     LLM_MODEL: str = Field(

--- a/a2a/slack_researcher/a2a_agent.py
+++ b/a2a/slack_researcher/a2a_agent.py
@@ -188,6 +188,8 @@ class ResearchExecutor(AgentExecutor):
                 async with (
                     streamablehttp_client(
                         url=settings.MCP_URL,
+                        timeout=settings.MCP_TIMEOUT,
+                        sse_read_timeout=settings.MCP_TIMEOUT,
                     ) as (
                         read_stream,
                         write_stream,

--- a/a2a/slack_researcher/slack_researcher/config.py
+++ b/a2a/slack_researcher/slack_researcher/config.py
@@ -3,7 +3,7 @@ import os
 from pydantic_settings import BaseSettings
 from pydantic import model_validator
 from pydantic import Field
-from typing import Literal
+from typing import Literal, Optional
 
 
 class Settings(BaseSettings):
@@ -33,6 +33,20 @@ class Settings(BaseSettings):
     )
     MCP_URL: str = Field(
         os.getenv("MCP_URL", "http://slack-tool:8000"), description="Endpoint for an option MCP server"
+    )
+    MCP_TIMEOUT: int = Field(os.getenv("MCP_TIMEOUT", 600), description="Timeout in seconds for MCP server connection")
+
+    # auth variables for token validation
+    ISSUER: Optional[str] = Field(os.getenv("ISSUER", None), description="The issuer for incoming JWT tokens")
+    JWKS_URI: Optional[str] = Field(os.getenv("JWKS_URI", None), description="Endpoint to obtain JWKS from auth server")
+
+    # auth variables for token exchange
+    TOKEN_URL: Optional[str] = Field(
+        os.getenv("TOKEN_URL", None), description="Token endpoint to obtain new access tokens"
+    )
+
+    TARGET_SCOPES: Optional[str] = Field(
+        os.getenv("TARGET_SCOPES", None), description="Target scopes to request during token exchange"
     )
     SERVICE_PORT: int = Field(os.getenv("PORT", 8000), description="Port on which the service will run.")
 


### PR DESCRIPTION
Replace hardcoded MCP connection timeouts with a configurable MCP_TIMEOUT environment variable (default 10 minutes) in git_issue_agent, simple_generalist, slack_researcher, and generic_agent.


Context  - HITL requires longer timeouts to not get to a timeout while waiting for user consent.
https://github.com/kagenti/kagenti/issues/1435


Fixes # https://github.com/kagenti/agent-examples/issues/519
