### PR TITLE
fix: add localhost prefix to image names to prevent Docker registry auto-prefixing

### DIFF
--- a/a2a/exgentic_agent/build.sh
+++ b/a2a/exgentic_agent/build.sh
@@ -40,7 +40,7 @@ detect_runtime() {
 build_agent() {
     local agent=$1
     local runtime=$2
-    local image_name="exgentic-a2a-${agent}"
+    local image_name="localhost/exgentic-a2a-${agent}"
     local tag=$3
     local use_cache=$4
     
@@ -184,7 +184,7 @@ EOF
         echo ""
         print_info "Built images:"
         for agent in "${AGENTS[@]}"; do
-            echo "  - exgentic-a2a-${agent}:${TAG}"
+            echo "  - localhost/exgentic-a2a-${agent}:${TAG}"
         done
     fi
 }

--- a/mcp/exgentic_benchmarks/build.sh
+++ b/mcp/exgentic_benchmarks/build.sh
@@ -40,7 +40,7 @@ detect_runtime() {
 build_benchmark() {
     local benchmark=$1
     local runtime=$2
-    local image_name="exgentic-mcp-${benchmark}"
+    local image_name="localhost/exgentic-mcp-${benchmark}"
     local tag=$3
     local use_cache=$4
     
@@ -189,7 +189,7 @@ EOF
         echo ""
         print_info "Built images:"
         for benchmark in "${BENCHMARKS[@]}"; do
-            echo "  - exgentic-mcp-${benchmark}:${TAG}"
+            echo "  - localhost/exgentic-mcp-${benchmark}:${TAG}"
         done
     fi
 }


### PR DESCRIPTION
## Problem
Docker automatically adds `docker.io/library/` prefix to unqualified image names, which causes:
- Inconsistencies between Docker and Podman image naming
- Breaks `docker inspect` commands when using short image names
- Different behavior between the two container runtimes

## Solution
Added `localhost/` prefix to image names in build scripts. This:
- Prevents Docker from auto-adding the `docker.io/library/` prefix
- Keeps images local (not pushed to any registry)
- Ensures consistent naming across both Docker and Podman
- Makes `docker inspect` and `podman inspect` work with the same image names

## Changes
- `a2a/exgentic_agent/build.sh`: Add localhost/ prefix to image names
- `mcp/exgentic_benchmarks/build.sh`: Add localhost/ prefix to image names

## Testing
After this change:
- Images will be tagged as `localhost/exgentic-a2a-AGENT:TAG` and `localhost/exgentic-mcp-BENCHMARK:TAG`
- `docker inspect localhost/exgentic-mcp-tau2:latest` will work correctly
- Both Docker and Podman will reference images consistently

## Commit
Signed-off-by: Yoav Katz <katz@il.ibm.com>