### PR TITLE
docs: Fix broken A2A protocol links

### DIFF
--- a/a2a/a2a_contact_extractor/README.md
+++ b/a2a/a2a_contact_extractor/README.md
@@ -76,4 +76,4 @@ with a validator to render things nicely if you want and maybe serialize weird t
 
 -   [Marvin Documentation](https://www.askmarvin.ai/)
 -   [Marvin GitHub Repository](https://github.com/prefecthq/marvin)
--   [A2A Protocol Documentation](https://google.github.io/A2A/#/documentation)
+-   [A2A Protocol Documentation](https://a2a-protocol.org/latest/)

--- a/a2a/a2a_currency_converter/README.md
+++ b/a2a/a2a_currency_converter/README.md
@@ -323,7 +323,7 @@ data: {"jsonrpc":"2.0","id":12,"result":{"id":"131","status":{"state":"completed
 
 ## Learn More
 
-- [A2A Protocol Documentation](https://google-a2a.github.io/A2A/)
+- [A2A Protocol Documentation](https://a2a-protocol.org/latest/)
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
 - [Frankfurter API](https://www.frankfurter.app/docs/)
 - [Google Gemini API](https://ai.google.dev/gemini-api)


### PR DESCRIPTION
## Summary

- Update A2A protocol URLs from deprecated domains to canonical `a2a-protocol.org/latest/`
- Old URLs (`google.github.io/A2A`, `google-a2a.github.io/A2A`) now 404; project moved under Linux Foundation

## Related issue(s)

- kagenti/kagenti#1694 (parent link-health effort)

Assisted-By: Claude Code