### PR TITLE
docs: Fix 2 broken internal link(s) in agent-examples

### DIFF
--- a/a2a/exgentic_agent/README.md
+++ b/a2a/exgentic_agent/README.md
@@ -1,6 +1,6 @@
 # Exgentic A2A Agent Wrapper
 
-A Docker-based wrapper that runs [Exgentic](https://github.com/Exgentic/exgentic) agents using the A2A (Agent-to-Agent) protocol. This wrapper clones the Exgentic repository, installs a specific agent at build time, and exposes it via the A2A interface.  These agents are used for evaluation against the [Exgentic benchmarks mcp servers](mcp/README.md).  The test harness used to evaluate the agents against the benchmarks is found in the [workload-harness repo](https://github.com/kagenti/workload-harness/blob/main/exgentic_a2a_runner/README.md).
+A Docker-based wrapper that runs [Exgentic](https://github.com/Exgentic/exgentic) agents using the A2A (Agent-to-Agent) protocol. This wrapper clones the Exgentic repository, installs a specific agent at build time, and exposes it via the A2A interface.  These agents are used for evaluation against the [Exgentic benchmarks mcp servers](mcp/README.md).  The test harness used to evaluate the agents against the benchmarks is found in the [workload-harness repo](https://github.com/kagenti/workload-harness/blob/main/README.md).
 
 ## Overview
 

--- a/mcp/exgentic_benchmarks/README.md
+++ b/mcp/exgentic_benchmarks/README.md
@@ -2,7 +2,7 @@
 
 A Docker-based MCP (Model Context Protocol) server that runs the [Exgentic](https://github.com/Exgentic/exgentic) benchmark system. This server clones the Exgentic repository, installs a specific benchmark at build time, and exposes it via the MCP protocol.
 
-The test harness used to evaluate the benchmark against agents is found in the [workload-harness repo](https://github.com/kagenti/workload-harness/blob/main/exgentic_a2a_runner/README.md).
+The test harness used to evaluate the benchmark against agents is found in the [workload-harness repo](https://github.com/kagenti/workload-harness/blob/main/README.md).
 
 ## Overview
 


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.
Broken internal links updated to point to current file locations.

| File | Old Path | New Path |
|------|----------|----------|
| `a2a/exgentic_agent/README.md` | `exgentic_a2a_runner/README.md` | `README.md` |
| `mcp/exgentic_benchmarks/README.md` | `exgentic_a2a_runner/README.md` | `README.md` |

Closes #700, #699