### PR TITLE
Refactor: Rename rossocortex → cortex (follow-up)

### DIFF
--- a/mcp/weather_tool/deployment/k8s.yaml
+++ b/mcp/weather_tool/deployment/k8s.yaml
@@ -34,7 +34,7 @@ metadata:
   labels:
     app.kubernetes.io/name: weather-tool
     rossoctl.io/framework: Python
-    # Set inject to true for [AuthBridge](https://github.com/rossoctl/rossocortex/tree/main/AuthBridge)
+    # Set inject to true for [AuthBridge](https://github.com/rossoctl/cortex/tree/main/AuthBridge)
     rossoctl.io/inject: disabled
     rossoctl.io/type: tool
     rossoctl.io/workload-type: deployment
@@ -54,7 +54,7 @@ spec:
       labels:
         app.kubernetes.io/name: weather-tool
         rossoctl.io/framework: Python
-        # Set inject to true for [AuthBridge](https://github.com/rossoctl/rossocortex/tree/main/AuthBridge)
+        # Set inject to true for [AuthBridge](https://github.com/rossoctl/cortex/tree/main/AuthBridge)
         rossoctl.io/inject: disabled
         rossoctl.io/transport: streamable_http
         rossoctl.io/type: tool


### PR DESCRIPTION
## Summary
Follow-up to the Kagenti → Rossoctl rename (#733): the extensions repo's final name is `cortex` (rossoctl/cortex), not `rossocortex`. Updates the one remaining reference (AuthBridge cross-repo link).

## Verification
- grep clean of `rossocortex` and `kagenti`

## Related issue(s)
Related to #1972